### PR TITLE
Fix gcimporter import path

### DIFF
--- a/type.go
+++ b/type.go
@@ -2,7 +2,8 @@ package gompatible
 
 import (
 	"go/types"
-	_ "golang.org/x/tools/go/gcimporter"
+
+	_ "golang.org/x/tools/go/gcimporter15"
 )
 
 // TypeChange represents a change between two types.


### PR DESCRIPTION
`golang.org/x/tools/go/gcimporter` has been moved to `golang.org/x/tools/go/gcimporter15`

It seems not used in code because can be built even without it, but now, cannot go gettable.
